### PR TITLE
Provide shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,18 +117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_complete"
-version = "4.5.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9501bd3f5f09f7bbee01da9a511073ed30a80cd7a509f1214bb74eadea71ad"
-dependencies = [
- "clap",
- "clap_lex",
- "is_executable",
- "shlex",
-]
-
-[[package]]
 name = "clap_derive"
 version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,7 +164,6 @@ name = "envswitch"
 version = "0.4.1"
 dependencies = [
  "clap",
- "clap_complete",
  "color-eyre",
  "escargot",
  "eyre",
@@ -284,15 +271,6 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
-name = "is_executable"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -466,12 +444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,28 +553,6 @@ checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,22 +10,20 @@ keywords    = ["shell", "cli"]
 categories  = ["command-line-utilities", "config"]
 
 [dependencies]
-clap          = { version = "4.5.45", features = ["derive"] }
-clap_complete = { version = "4.5.57", features = ["unstable-dynamic"] }
-color-eyre    = { version = "0.6.5", default-features = false }
-eyre          = { version = "0.6.12", default-features = false }
-indexmap      = { version = "2.10.0", features = ["serde"] }
-itertools     = "0.14.0"
-serde         = { version = "1.0.219", features = ["derive"] }
-toml          = { version = "0.9.5", features = ["serde"] }
-indoc         = "2.0.6"
+clap       = { version = "4.5.45", features = ["derive"] }
+color-eyre = { version = "0.6.5", default-features = false }
+eyre       = { version = "0.6.12", default-features = false }
+indexmap   = { version = "2.10.0", features = ["serde"] }
+itertools  = "0.14.0"
+serde      = { version = "1.0.219", features = ["derive"] }
+toml       = { version = "0.9.5", features = ["serde"] }
 
 [dev-dependencies]
 escargot = "0.5.15"
+indoc    = "2.0.6"
 strum    = { version = "0.27.2", features = ["derive"] }
 tempfile = "3.20.0"
 
-# The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
 lto      = "thin"

--- a/README.md
+++ b/README.md
@@ -70,9 +70,8 @@ various platforms is easy.
 It is strongly recommended that you run `envswitch` through a shell function, as
 otherwise it just outputs shell commands that need to be sourced.
 
-Please place the appropriate snippet in your shell config. It will register the
-function `es`; if you'd prefer another name, you can run the `setup` command
-yourself and copy the output to your config with any desired changed.
+Please place the appropriate snippet in your shell config (e.g. ~/.bashrc). It
+will register the function `es` and generate completions for it.
 
 ### Bash
 

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,12 @@
         ];
 
         commonArgs = {
-          src = craneLib.cleanCargoSource ./.;
+          src = pkgs.lib.fileset.toSource {
+            root = ./.;
+            fileset = pkgs.lib.fileset.union (pkgs.lib.fileset.fromSource (craneLib.cleanCargoSource ./.)) (
+              pkgs.lib.fileset.fileFilter (file: true) ./src/shell
+            );
+          };
           strictDeps = true;
           nativeBuildInputs = shells;
         };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,10 +27,10 @@ pub enum Commands {
     Get,
     /// Set the environment
     Set(Set),
-    /// Generate shell completions
-    Completions(Completions),
     /// Generate a command to integrate envswitch with your shell
     Setup(Setup),
+    #[clap(hide = true)]
+    Complete(Complete),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -56,14 +56,20 @@ pub struct ConfigPath {
     pub file: Option<PathBuf>,
 }
 
-// TODO: Try to get nice completions working for `env`.
-// fn env_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
-//     todo!("current: {current:?}")
-// }
-
 #[derive(Debug, Clone, Args)]
-pub struct Completions {
-    pub shell: Shell,
+pub struct Complete {
+    #[command(flatten)]
+    pub config: ConfigPath,
+
+    // NOTE: We accept multiple positional arguments here just to make completion
+    // not error if you hit TAB too many times. We only use the first one.
+    #[arg(default_value = "")]
+    pub env: Vec<String>,
+
+    // We don't use this, but we need to respect all arguments that might be
+    // passed into `es`.
+    #[arg(short, long)]
+    list: bool,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/src/shell/bash_setup.sh
+++ b/src/shell/bash_setup.sh
@@ -1,0 +1,34 @@
+es() {
+    local env
+    env=$(BIN set -sbash "$@") || return $?
+    eval "$env"
+}
+
+_es_completion() {
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # Handle flag arguments
+    case "${prev}" in
+        -f|--file)
+            # File completion for -f/--file
+            mapfile -t COMPREPLY < <(compgen -f -- "${cur}")
+            return 0
+            ;;
+    esac
+
+    # Handle flags
+    if [[ ${cur} == -* ]]; then
+        opts="-f --file -l --list"
+        mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
+        return 0
+    fi
+
+    # Handle dynamic env argument
+    local args=("${COMP_WORDS[@]:1}")
+    local completions
+    mapfile -t completions < <(BIN complete "${args[@]}" 2>/dev/null)
+    mapfile -t COMPREPLY < <(compgen -W "${completions[*]}" -- "${cur}")
+}

--- a/src/shell/fish_setup.fish
+++ b/src/shell/fish_setup.fish
@@ -1,0 +1,14 @@
+function es
+    BIN set -sfish $argv | source
+    return $pipestatus[1]
+end
+
+complete -c es -e
+complete -c es -s f -l file -d "Config file" -r -F
+complete -c es -s l -l list -d "List available environments"
+
+function __es_complete_positional
+    BIN complete (commandline -opc)[2..] 2>/dev/null
+end
+
+complete -c es -f -a '(__es_complete_positional)'

--- a/src/shell/zsh_setup.zsh
+++ b/src/shell/zsh_setup.zsh
@@ -1,0 +1,30 @@
+es() {
+    local env
+    env=$(BIN set -szsh "$@") || return $?
+    eval "$env"
+}
+
+autoload -U compinit && compinit
+
+_es() {
+    local context state line
+    typeset -A opt_args
+
+    _arguments \
+        '(-f --file)'{-f,--file}'[Config File]:file:_files' \
+        '(-l --list)'{-l,--list}'[List available environments]' \
+        '*::positional:_es_positional'
+}
+
+_es_positional() {
+    local -a completions
+
+    local -a full_line=(${(z)BUFFER})
+    local -a args=("${full_line[@]:1}")
+
+    completions=(${(f)"$(BIN complete ${args[@]} 2>/dev/null)"})
+
+    _describe 'environments' completions
+}
+
+compdef '_es' 'es'


### PR DESCRIPTION
We give up on `clap_complete` and provide completions manually.

These are setup imperfectly; for example, it will sometimes offer to
complete the same argument multiple times.

But, for the simple case where you just want to autocomplete the ENV,
they work quite nicely.